### PR TITLE
Gazebo mirror

### DIFF
--- a/mirror/files/mirror.list
+++ b/mirror/files/mirror.list
@@ -140,38 +140,38 @@ clean http://packages.ros.org/ros/ubuntu
 
 # Gazebo Repositories
 
-deb http://packages.osrfoundation.org/gazebo/ubuntu precise main
-deb-i386 http://packages.osrfoundation.org/gazebo/ubuntu precise main
+deb http://packages.osrfoundation.org/gazebo/ubuntu-stable precise main
+deb-i386 http://packages.osrfoundation.org/gazebo/ubuntu-stable precise main
 
-deb http://packages.osrfoundation.org/gazebo/ubuntu trusty main
-#deb-arm64 http://packages.osrfoundation.org/gazebo/ubuntu trusty main
-deb-armhf http://packages.osrfoundation.org/gazebo/ubuntu trusty main
-deb-i386 http://packages.osrfoundation.org/gazebo/ubuntu trusty main
-deb-src http://packages.osrfoundation.org/gazebo/ubuntu trusty main
+deb http://packages.osrfoundation.org/gazebo/ubuntu-stable trusty main
+#deb-arm64 http://packages.osrfoundation.org/gazebo/ubuntu-stable trusty main
+deb-armhf http://packages.osrfoundation.org/gazebo/ubuntu-stable trusty main
+deb-i386 http://packages.osrfoundation.org/gazebo/ubuntu-stable trusty main
+deb-src http://packages.osrfoundation.org/gazebo/ubuntu-stable trusty main
 
-deb http://packages.osrfoundation.org/gazebo/ubuntu xenial main
-#deb-arm64 http://packages.osrfoundation.org/gazebo/ubuntu xenial main
-deb-armhf http://packages.osrfoundation.org/gazebo/ubuntu xenial main
-deb-i386 http://packages.osrfoundation.org/gazebo/ubuntu xenial main
-deb-src http://packages.osrfoundation.org/gazebo/ubuntu xenial main
+deb http://packages.osrfoundation.org/gazebo/ubuntu-stable xenial main
+#deb-arm64 http://packages.osrfoundation.org/gazebo/ubuntu-stable xenial main
+deb-armhf http://packages.osrfoundation.org/gazebo/ubuntu-stable xenial main
+deb-i386 http://packages.osrfoundation.org/gazebo/ubuntu-stable xenial main
+deb-src http://packages.osrfoundation.org/gazebo/ubuntu-stable xenial main
 
-deb http://packages.osrfoundation.org/gazebo/ubuntu yakkety main
-#deb-arm64 http://packages.osrfoundation.org/gazebo/ubuntu yakkety main
-deb-armhf http://packages.osrfoundation.org/gazebo/ubuntu yakkety main
-deb-i386 http://packages.osrfoundation.org/gazebo/ubuntu yakkety main
-deb-src http://packages.osrfoundation.org/gazebo/ubuntu yakkety main
+deb http://packages.osrfoundation.org/gazebo/ubuntu-stable yakkety main
+#deb-arm64 http://packages.osrfoundation.org/gazebo/ubuntu-stable yakkety main
+deb-armhf http://packages.osrfoundation.org/gazebo/ubuntu-stable yakkety main
+deb-i386 http://packages.osrfoundation.org/gazebo/ubuntu-stable yakkety main
+deb-src http://packages.osrfoundation.org/gazebo/ubuntu-stable yakkety main
 
-deb http://packages.osrfoundation.org/gazebo/ubuntu zesty main
-#deb-arm64 http://packages.osrfoundation.org/gazebo/ubuntu zesty main
-deb-armhf http://packages.osrfoundation.org/gazebo/ubuntu zesty main
-deb-i386 http://packages.osrfoundation.org/gazebo/ubuntu zesty main
-deb-src http://packages.osrfoundation.org/gazebo/ubuntu zesty main
+deb http://packages.osrfoundation.org/gazebo/ubuntu-stable zesty main
+#deb-arm64 http://packages.osrfoundation.org/gazebo/ubuntu-stable zesty main
+deb-armhf http://packages.osrfoundation.org/gazebo/ubuntu-stable zesty main
+deb-i386 http://packages.osrfoundation.org/gazebo/ubuntu-stable zesty main
+deb-src http://packages.osrfoundation.org/gazebo/ubuntu-stable zesty main
 
-deb http://packages.osrfoundation.org/gazebo/ubuntu artful main
-#deb-arm64 http://packages.osrfoundation.org/gazebo/ubuntu artful main
-deb-armhf http://packages.osrfoundation.org/gazebo/ubuntu artful main
-deb-i386 http://packages.osrfoundation.org/gazebo/ubuntu artful main
-deb-src http://packages.osrfoundation.org/gazebo/ubuntu artful main
+deb http://packages.osrfoundation.org/gazebo/ubuntu-stable artful main
+#deb-arm64 http://packages.osrfoundation.org/gazebo/ubuntu-stable artful main
+deb-armhf http://packages.osrfoundation.org/gazebo/ubuntu-stable artful main
+deb-i386 http://packages.osrfoundation.org/gazebo/ubuntu-stable artful main
+deb-src http://packages.osrfoundation.org/gazebo/ubuntu-stable artful main
 
 deb http://packages.osrfoundation.org/gazebo/debian-stable jessie main
 #deb-arm64 http://packages.osrfoundation.org/gazebo/debian-stable jessie main
@@ -186,4 +186,4 @@ deb-i386 http://packages.osrfoundation.org/gazebo/debian-stable stretch main
 deb-src http://packages.osrfoundation.org/gazebo/debian-stable stretch main
 
 clean http://packages.osrfoundation.org/gazebo/debian-stable
-clean http://packages.osrfoundation.org/gazebo/ubuntu
+clean http://packages.osrfoundation.org/gazebo/ubuntu-stable

--- a/mirror/files/mirror.list
+++ b/mirror/files/mirror.list
@@ -173,6 +173,12 @@ deb-armhf http://packages.osrfoundation.org/gazebo/ubuntu-stable artful main
 deb-i386 http://packages.osrfoundation.org/gazebo/ubuntu-stable artful main
 deb-src http://packages.osrfoundation.org/gazebo/ubuntu-stable artful main
 
+deb http://packages.osrfoundation.org/gazebo/ubuntu-stable bionic main
+#deb-arm64 http://packages.osrfoundation.org/gazebo/ubuntu-stable bionic main
+deb-armhf http://packages.osrfoundation.org/gazebo/ubuntu-stable bionic main
+deb-i386 http://packages.osrfoundation.org/gazebo/ubuntu-stable bionic main
+deb-src http://packages.osrfoundation.org/gazebo/ubuntu-stable bionic main
+
 deb http://packages.osrfoundation.org/gazebo/debian-stable jessie main
 #deb-arm64 http://packages.osrfoundation.org/gazebo/debian-stable jessie main
 deb-armhf http://packages.osrfoundation.org/gazebo/debian-stable jessie main


### PR DESCRIPTION
Switch the Gazebo mirror to use ubuntu-stable instead of ubuntu; according to Jose, that is more correct, although they are currently equivalent.  Also add in mirroring of the Gazebo repositories for bionic.  Note that I have not been able to test this, as running the instructions in the `README.md` don't seem to work; any advice there is appreciated.