### PR TITLE
Update for compatibility with puppet v5.5.2, closes #4

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ sudo puppet module install puppetlabs/rsync
 sudo puppet module install puppet-unattended_upgrades
 git clone https://github.com/ros-infrastructure/mirror.git
 cd mirror
-sudo puppet apply ros_mirror.pp --modulepath=/etc/puppetlabs/code/modules:.
+sudo puppet apply ros_mirror.pp --modulepath=/etc/puppet/modules:/etc/puppetlabs/code/modules:. # /etc/puppet/modules can be removed after EOL support for puppet 3.x
 ```
 
 Overnight the sync jobs will run and you can see that they are setup correctly by running:

--- a/README.md
+++ b/README.md
@@ -3,9 +3,9 @@ ROS Mirror Puppet Manifest
 
 This repo provides a way to easily mirror the ROS services. 
 
-The machine will need ~ 150 GB of disk space in the /mirror directory and as much bandwidth as you plan to pull. 
+The machine will need ~ 200 GB of disk space in the /mirror directory and as much bandwidth as you plan to pull. 
 
-This is tested on Ubuntu Precise LTS
+This is tested on Ubuntu Xenial LTS (16.04) and Ubuntu Bionic LTS (18.04)
 
 How to Setup
 ------------
@@ -15,13 +15,14 @@ Run the following commands:
 ```
 sudo apt-get update
 sudo apt-get install rubygems git
-sudo gem install puppet --no-ri --no-rdoc -v 3.8.7
+sudo gem install puppet --no-ri --no-rdoc
+sudo puppet module install puppetlabs-apt
 sudo puppet module install puppetlabs/apache
 sudo puppet module install puppetlabs/rsync
 sudo puppet module install puppet-unattended_upgrades
 git clone https://github.com/ros-infrastructure/mirror.git
 cd mirror
-sudo puppet apply ros_mirror.pp --modulepath=/etc/puppet/modules:/usr/share/puppet/modules:.
+sudo puppet apply ros_mirror.pp --modulepath=/etc/puppetlabs/code/modules:.
 ```
 
 Overnight the sync jobs will run and you can see that they are setup correctly by running:

--- a/ros_mirror.pp
+++ b/ros_mirror.pp
@@ -1,4 +1,4 @@
-import 'mirror'
+include 'mirror'
 
 include apt
 
@@ -17,14 +17,14 @@ package { 'apt-mirror':
 
 file {'/mirror/packages.ros.org/mirror.list':
   ensure => file,
-  mode => 664,
+  mode => '0664',
   owner => 'rosmirror',
   source => 'puppet:///modules/mirror/mirror.list',
 }
 
 file {['/mirror', '/mirror/packages.ros.org', '/mirror/packages.ros.org/mirror', '/mirror/packages.ros.org/mirror/packages.ros.org', '/mirror/packages.ros.org/mirror/packages.osrfoundation.org', '/mirror/wiki.ros.org', '/mirror/docs.ros.org']:
   ensure => directory,
-  mode   => 644,
+  mode   => '0644',
   owner  => 'rosmirror',
   before => [ Apache::Vhost['packages.ros.org.mirror'],
               File['/mirror/packages.ros.org/mirror.list'] ],


### PR DESCRIPTION
When trying to run the puppet script on our new 18.04 server, I got the error below which seems to be related to the usage of an old puppet version (3.8.7). This PR updates the script so that it runs with the current puppet version. I have tested it on 16.04 and 18.04.

```
sudo puppet module install puppetlabs/apache
Traceback (most recent call last):
	17: from /usr/local/bin/puppet:23:in `<main>'
	16: from /usr/local/bin/puppet:23:in `load'
	15: from /var/lib/gems/2.5.0/gems/puppet-3.8.7/bin/puppet:7:in `<top (required)>'
	14: from /usr/lib/ruby/2.5.0/rubygems/core_ext/kernel_require.rb:59:in `require'
	13: from /usr/lib/ruby/2.5.0/rubygems/core_ext/kernel_require.rb:59:in `require'
	12: from /var/lib/gems/2.5.0/gems/puppet-3.8.7/lib/puppet/util/command_line.rb:12:in `<top (required)>'
	11: from /usr/lib/ruby/2.5.0/rubygems/core_ext/kernel_require.rb:59:in `require'
	10: from /usr/lib/ruby/2.5.0/rubygems/core_ext/kernel_require.rb:59:in `require'
	 9: from /var/lib/gems/2.5.0/gems/puppet-3.8.7/lib/puppet.rb:8:in `<top (required)>'
	 8: from /usr/lib/ruby/2.5.0/rubygems/core_ext/kernel_require.rb:59:in `require'
	 7: from /usr/lib/ruby/2.5.0/rubygems/core_ext/kernel_require.rb:59:in `require'
	 6: from /var/lib/gems/2.5.0/gems/puppet-3.8.7/lib/puppet/util.rb:14:in `<top (required)>'
	 5: from /var/lib/gems/2.5.0/gems/puppet-3.8.7/lib/puppet/util.rb:15:in `<module:Puppet>'
	 4: from /var/lib/gems/2.5.0/gems/puppet-3.8.7/lib/puppet/util.rb:16:in `<module:Util>'
	 3: from /usr/lib/ruby/2.5.0/rubygems/core_ext/kernel_require.rb:59:in `require'
	 2: from /usr/lib/ruby/2.5.0/rubygems/core_ext/kernel_require.rb:59:in `require'
	 1: from /var/lib/gems/2.5.0/gems/puppet-3.8.7/lib/puppet/util/monkey_patches.rb:172:in `<top (required)>'
/var/lib/gems/2.5.0/gems/puppet-3.8.7/lib/puppet/util/monkey_patches.rb:178:in `<class:SSLContext>': undefined method `<<' for nil:NilClass (NoMethodError)
```
